### PR TITLE
Update DEVELOPER_INSTRUCTIONS.md

### DIFF
--- a/doc/DEVELOPER_INSTRUCTIONS.md
+++ b/doc/DEVELOPER_INSTRUCTIONS.md
@@ -66,7 +66,7 @@ We recommend you to use the open source development environment of [Visual Studi
  * Go to the extensions marketplace (Ctrl+Shift+X)
  * Install the following extensions:
 	 * Python (Microsoft)
-	 * Anaconda Extension Pack (Microsoft)
+	 * YAML (Red Hat)
 	 * Python-autopep8 (himanoa)
 	 * cornflakes-linter (kevinglasson)
  * On Visual Studio Code, press Ctrl+Shif+P and write "Open Settings (JSON)". The configuration file should look like this:


### PR DESCRIPTION
The Microsoft Python extension pack is no longer available. It consisted of the Microsoft Python extension and the Red Hat YAML extension. Installing the packages as stated results in the same setup as before.